### PR TITLE
Updating Configure Redis using a ConfigMap Tutorial

### DIFF
--- a/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
+++ b/content/en/docs/tutorials/configuration/configure-redis-using-configmap.md
@@ -9,37 +9,30 @@ weight: 30
 
 <!-- overview -->
 
-This page provides a real world example of how to configure Redis using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task. 
-
-
+This tutorial describes how to configure a [Redis](https://redis.io/) cache using a ConfigMap and builds upon the [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/) task.
 
 ## {{% heading "objectives" %}}
 
-
-* Create a ConfigMap with Redis configuration values
-* Create a Redis Pod that mounts and uses the created ConfigMap
-* Verify that the configuration was correctly applied.
-
-
+* Create a ConfigMap with Redis configuration values.
+* Create a Redis Pod that mounts and uses the ConfigMap.
+* Update the configuration values.
+* Verify that the configuration update was correctly applied.
 
 ## {{% heading "prerequisites" %}}
 
-
 {{< include "task-tutorial-prereqs.md" >}} {{< version-check >}}
 
-* The example shown on this page works with `kubectl` 1.14 and above.
-* Understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
-
-
+* Read and understand the [ConfigMap](/docs/concepts/configuration/configmap/) API object.
+* Read and understand [Configure a Pod to Use a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
+* Ensure that `kubectl` is version 1.14 or above.
 
 <!-- lessoncontent -->
 
-
-## Real World Example: Configuring Redis using a ConfigMap
+## Create and apply a Redis cache using a ConfigMap
 
 Follow the steps below to configure a Redis cache using data stored in a ConfigMap.
 
-First create a ConfigMap with an empty configuration block:
+First [create a ConfigMap from a generator](/docs/tasks/configure-pod-container/configure-pod-configmap/#create-a-configmap-from-generator) with an empty configuration block:
 
 ```shell
 cat <<EOF >./example-redis-config.yaml
@@ -52,26 +45,30 @@ data:
 EOF
 ```
 
-Apply the ConfigMap created above, along with a Redis pod manifest:
+Apply the configuration in the ConfigMap, along with a Redis pod manifest:
 
 ```shell
 kubectl apply -f example-redis-config.yaml
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
 ```
 
-Examine the contents of the Redis pod manifest and note the following:
+## Review the Redis pod manifest
 
-* A volume named `config` is created by `spec.volumes[1]`
+Examine the contents of the Redis pod manifest and note the following details of the configuration:
+
+* A [volume](/docs/concepts/storage/volumes/) named `config` is created by `spec.volumes[1]`.
 * The `key` and `path` under `spec.volumes[1].configMap.items[0]` exposes the `redis-config` key from the 
   `example-redis-config` ConfigMap as a file named `redis.conf` on the `config` volume.
 * The `config` volume is then mounted at `/redis-master` by `spec.containers[0].volumeMounts[1]`.
 
-This has the net effect of exposing the data in `data.redis-config` from the `example-redis-config`
-ConfigMap above as `/redis-master/redis.conf` inside the Pod.
+This configuration exposes the data in `data.redis-config` from the `example-redis-config`
+ConfigMap above as [`redis.conf`](https://redis.io/docs/latest/operate/oss_and_stack/management/config/) file inside the Pod.
 
 {{% code_sample file="pods/config/redis-pod.yaml" %}}
 
-Examine the created objects:
+## Verify the ConfigMap is correctly set up
+
+Examine the created objects to make sure that the ConfigMap is correctly set up:
 
 ```shell
 kubectl get pod/redis configmap/example-redis-config 
@@ -87,13 +84,13 @@ NAME                             DATA   AGE
 configmap/example-redis-config   1      14s
 ```
 
-Recall that we left `redis-config` key in the `example-redis-config` ConfigMap blank:
+Ensure that the `redis-config` key is blank when you print a detailed description of the `example-redis-config` ConfigMap:
 
 ```shell
 kubectl describe configmap/example-redis-config
 ```
 
-You should see an empty `redis-config` key:
+The description should display an empty `redis-config` key:
 
 ```shell
 Name:         example-redis-config
@@ -106,39 +103,11 @@ Data
 redis-config:
 ```
 
-Use `kubectl exec` to enter the pod and run the `redis-cli` tool to check the current configuration:
+## Updating configuration values
 
-```shell
-kubectl exec -it redis -- redis-cli
-```
+You can add Redis configuration values to the YAML file, and then check the configuration with [`redis-cli`](https://redis.io/docs/latest/develop/tools/cli/).
 
-Check `maxmemory`:
-
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
-
-It should show the default value of 0:
-
-```shell
-1) "maxmemory"
-2) "0"
-```
-
-Similarly, check `maxmemory-policy`:
-
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
-
-Which should also yield its default value of `noeviction`:
-
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
-
-Now let's add some configuration values to the `example-redis-config` ConfigMap:
+Add a `maxmemory` and `maxmemory-policy` value to the `example-redis-config` ConfigMap in order to [configure Redis as a cache](https://redis.io/docs/latest/operate/oss_and_stack/management/config/#configuring-redis-as-a-cache):
 
 {{% code_sample file="pods/config/example-redis-config.yaml" %}}
 
@@ -147,6 +116,15 @@ Apply the updated ConfigMap:
 ```shell
 kubectl apply -f example-redis-config.yaml
 ```
+
+The Pod needs to be restarted to grab the updated values from any associated ConfigMaps. Delete and recreate the Pod:
+
+```shell
+kubectl delete pod redis
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
+```
+
+### Verify the ConfigMap updates with kubectl
 
 Confirm that the ConfigMap was updated:
 
@@ -170,7 +148,9 @@ maxmemory 2mb
 maxmemory-policy allkeys-lru
 ```
 
-Check the Redis Pod again using `redis-cli` via `kubectl exec` to see if the configuration was applied:
+### Verify the configuration updates with redis-cli
+
+Check the Redis Pod using `redis-cli` via `kubectl exec` to see if the configuration was applied:
 
 ```shell
 kubectl exec -it redis -- redis-cli
@@ -182,54 +162,14 @@ Check `maxmemory`:
 127.0.0.1:6379> CONFIG GET maxmemory
 ```
 
-It remains at the default value of 0:
-
-```shell
-1) "maxmemory"
-2) "0"
-```
-
-Similarly, `maxmemory-policy` remains at the `noeviction` default setting:
-
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory-policy
-```
-
-Returns:
-
-```shell
-1) "maxmemory-policy"
-2) "noeviction"
-```
-
-The configuration values have not changed because the Pod needs to be restarted to grab updated
-values from associated ConfigMaps. Let's delete and recreate the Pod:
-
-```shell
-kubectl delete pod redis
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/pods/config/redis-pod.yaml
-```
-
-Now re-check the configuration values one last time:
-
-```shell
-kubectl exec -it redis -- redis-cli
-```
-
-Check `maxmemory`:
-
-```shell
-127.0.0.1:6379> CONFIG GET maxmemory
-```
-
-It should now return the updated value of 2097152:
+It now reflects the updated value of 2097152:
 
 ```shell
 1) "maxmemory"
 2) "2097152"
 ```
 
-Similarly, `maxmemory-policy` has also been updated:
+Check `maxmemory-policy`:
 
 ```shell
 127.0.0.1:6379> CONFIG GET maxmemory-policy
@@ -242,6 +182,8 @@ It now reflects the desired value of `allkeys-lru`:
 2) "allkeys-lru"
 ```
 
+## Cleanup your work
+
 Clean up your work by deleting the created resources:
 
 ```shell
@@ -250,6 +192,7 @@ kubectl delete pod/redis configmap/example-redis-config
 
 ## {{% heading "whatsnext" %}}
 
-
-* Learn more about [ConfigMaps](/docs/tasks/configure-pod-container/configure-pod-configmap/).
 * Follow an example of [Updating configuration via a ConfigMap](/docs/tutorials/configuration/updating-configuration-via-a-configmap/).
+* Learn how to [configure a Pod using a ConfigMap](/docs/tasks/configure-pod-container/configure-pod-configmap/).
+* Learn more about [Using ConfigMaps as files from a Pod](/docs/concepts/configuration/configmap/#using-configmaps-as-files-from-a-pod).
+* Learn about [Configuration best practices](/docs/concepts/configuration/overview/).


### PR DESCRIPTION
Draft update of the  [Configure Redis using a ConfigMap Tutorial](https://kubernetes.io/docs/tutorials/configuration/configure-redis-using-configmap/) on the Kubernetes website 